### PR TITLE
Fix rate limit response typo

### DIFF
--- a/pages/api/ask-llm.js
+++ b/pages/api/ask-llm.js
@@ -181,7 +181,7 @@ export default async function handler(req, res) {
     if (rate >= 10) {
       return res
         .status(429)
-        .json({ messateste: 'Too many requests—please slow down.' });
+        .json({ message: 'Too many requests—please slow down.' });
     }
     await kv.set(rateKey, rate + 1, { ex: 60 });
 


### PR DESCRIPTION
## Summary
- correct property name in rate-limit API response

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683ca3b666388321b58a12b015a2b2fc