### PR TITLE
Update trended fails slice logic

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -572,9 +572,10 @@ export default function Dashboard() {
   const displayedRuns = showAll ? sortedRuns : sortedRuns.slice(0, 7);
 
   const trendedFailedTests = useMemo(() => {
-    const last30Runs = sortedRuns.slice(0, 16);
+    // Aggregate failures from the last 16 runs
+    const last16Runs = sortedRuns.slice(0, 16);
     const aggregated = {};
-    last30Runs.forEach(run => {
+    last16Runs.forEach(run => {
       if (run.failed_tests) {
         Object.entries(run.failed_tests).forEach(([testId, count]) => {
           aggregated[testId] = (aggregated[testId] || 0) + count;


### PR DESCRIPTION
## Summary
- rename variable to `last16Runs`
- note in comment that trended fails uses the last 16 runs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ca61399408321a62fa0fe85777945