### PR TITLE
Enhance TC-01 hero banner coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The QA Automation Tool:
 
 | ID      | Name                        | Description                                          |
 |---------|-----------------------------|------------------------------------------------------|
-| **TC-01** | Hero Overlay on Desktop    | Hero text visible and positioned at 1920×1080        |
+| **TC-01** | Hero Overlay on Desktop    | Hero text visible at 1920×1080 for homepage, category, product and custom hero banners |
 | **TC-02** | Hero Static on Mobile      | Hero text visible on 375×667 viewport                |
 | **TC-03** | Header Presence            | `<header>` or class containing “header”              |
 | **TC-04** | Navigation Presence        | `<nav>` or class containing “nav”                    |
@@ -85,6 +85,12 @@ The QA Automation Tool:
 | **TC-12** | DocCheck Login Route       | Incognito → URL includes `/account/doccheck-login`   |
 | **TC-13** | DE Nav Redirect            | “Produkte → Ultraschall → Mehr erfahren” → target site |
 | **TC-14** | HTTP Status Code Valid     | Status 200 or valid redirect (301/302)               |
+
+Supported hero components for **TC-01**:
+- `.ge-homepage-hero-v2-component`
+- `.ge-category-hero__container`
+- `.hero-content-intro`
+- `.product-heroV2-container`
 
 For details and any custom extraction, use the dashboard’s **Test Definitions** section.
 

--- a/api/qa-test.js
+++ b/api/qa-test.js
@@ -31,6 +31,7 @@ import fetch from 'node-fetch';
 import pTimeout from 'p-timeout';
 import { v4 as uuidv4 } from 'uuid';
 import 'dotenv/config';
+import { heroTextVisible } from '../utils/hero.js';
 
 // Logger setup (Winston)
 const logger = winston.createLogger({
@@ -713,9 +714,8 @@ function getBlobConfig() {
 
           switch (id) {
             case 'TC-01': {
-              // Verify hero text is visible on the homepage
-              const heroText = await page.$('section.ge-homepage-hero-v2-component .ge-homepage-hero-v2__text-content');
-              pass = heroText && await heroText.isVisible();
+              // Verify hero text is visible on supported hero components
+              pass = await heroTextVisible(page);
               errorDetails = pass ? '' : 'Hero text not found or not visible in hero section';
               break;
             }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+export const heroSelectors = [
+  'section.ge-homepage-hero-v2-component .ge-homepage-hero-v2__text-content',
+  '.ge-category-hero__container .ge-category-hero__details',
+  '.hero-content-intro.ptags',
+  'section.product-heroV2-container .product-heroV2-container__title'
+];
+

--- a/tests/hero-utils.test.js
+++ b/tests/hero-utils.test.js
@@ -1,0 +1,29 @@
+import { heroTextVisible } from '../utils/hero.js';
+
+// Mock isVisible helper
+function visibleElement() {
+  return { isVisible: async () => true };
+}
+
+function hiddenElement() {
+  return { isVisible: async () => false };
+}
+
+describe('heroTextVisible', () => {
+  test('returns true when any selector is visible', async () => {
+    const page = {
+      $: jest.fn(sel => sel === '.b' ? visibleElement() : null)
+    };
+    const result = await heroTextVisible(page, ['.a', '.b']);
+    expect(page.$).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
+  });
+
+  test('returns false when no selectors are visible', async () => {
+    const page = { $: jest.fn(() => null) };
+    const result = await heroTextVisible(page, ['.a', '.b']);
+    expect(page.$).toHaveBeenCalledTimes(2);
+    expect(result).toBe(false);
+  });
+});
+

--- a/utils/hero.js
+++ b/utils/hero.js
@@ -1,0 +1,12 @@
+import { heroSelectors as defaultSelectors } from '../config.js';
+
+export async function heroTextVisible(page, selectors = defaultSelectors) {
+  for (const sel of selectors) {
+    const el = await page.$(sel);
+    if (el && await el.isVisible()) {
+      return true;
+    }
+  }
+  return false;
+}
+


### PR DESCRIPTION
## Summary
- extend TC-01 to work with various hero banners
- provide configurable hero selectors via `config.js`
- add helper `heroTextVisible()` used by TC-01
- document supported hero components
- add unit tests for hero selector logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cdac5eb808321b9c2e75cceaad245