### PR TITLE
Expand hero visibility checks on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The QA Automation Tool:
 | ID      | Name                        | Description                                          |
 |---------|-----------------------------|------------------------------------------------------|
 | **TC-01** | Hero Overlay on Desktop    | Hero text visible at 1920×1080 for homepage, category, product and custom hero banners |
-| **TC-02** | Hero Static on Mobile      | Hero text visible on 375×667 viewport                |
+| **TC-02** | Hero Static on Mobile      | Hero text visible on 375×667 viewport for homepage, category, product and custom hero banners |
 | **TC-03** | Header Presence            | `<header>` or class containing “header”              |
 | **TC-04** | Navigation Presence        | `<nav>` or class containing “nav”                    |
 | **TC-05** | Main Content               | `<main>` or class containing “main”                  |
@@ -87,6 +87,7 @@ The QA Automation Tool:
 | **TC-14** | HTTP Status Code Valid     | Status 200 or valid redirect (301/302)               |
 
 Supported hero components for **TC-01**:
+- `div[id*="ge-homepage-hero"]`
 - `.ge-homepage-hero-v2-component`
 - `.ge-category-hero__container`
 - `.hero-content-intro`

--- a/api/qa-test.js
+++ b/api/qa-test.js
@@ -742,9 +742,8 @@ function getBlobConfig() {
               break;
             }
             case 'TC-02': {
-              // Verify hero text is visible on mobile viewport
-              const heroText = await page.$('div[id*="ge-homepage-hero"] .ge-homepage-hero-v2__text-content, section.ge-homepage-hero-v2-component .ge-homepage-hero-v2__text-content');
-              pass = heroText && await heroText.isVisible();
+              // Verify hero text is visible on mobile viewport for all supported hero components
+              pass = await heroTextVisible(page);
               errorDetails = pass ? '' : 'Hero text not found or not visible on mobile viewport';
               break;
             }

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 // Selector list used by heroTextVisible to detect hero text on various pages
 export const heroSelectors = [
+  'div[id*="ge-homepage-hero"] .ge-homepage-hero-v2__text-content',
   'section.ge-homepage-hero-v2-component .ge-homepage-hero-v2__text-content',
   '.ge-category-hero__container .ge-category-hero__details',
   '.hero-content-intro.ptags',


### PR DESCRIPTION
## Summary
- broaden TC-02 logic to use general hero selectors
- include homepage ID selector in the hero list
- document additional mobile hero support

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dcf6887b48321a0146db3040a605c