### PR TITLE
Normalize test blob secret name

### DIFF
--- a/.github/workflows/run-qa.yml
+++ b/.github/workflows/run-qa.yml
@@ -78,12 +78,14 @@ jobs:
             echo "Using TEST environment secrets"
             echo "SUPABASE_URL=${{ secrets.TEST_SUPABASE_URL }}" >> $GITHUB_ENV
             echo "SUPABASE_SERVICE_ROLE_KEY=${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY }}" >> $GITHUB_ENV
-            echo "BLOB_READ_WRITE_TOKEN=${{ secrets.blobTest_READ_WRITE_TOKEN }}" >> $GITHUB_ENV
+            echo "BLOB_READ_WRITE_TOKEN=${{ secrets.TEST_BLOB_READ_WRITE_TOKEN }}" >> $GITHUB_ENV
+            echo "VERCEL_ENV=preview" >> $GITHUB_ENV
           else
             echo "Using PROD environment secrets"
             echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> $GITHUB_ENV
             echo "SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" >> $GITHUB_ENV
             echo "BLOB_READ_WRITE_TOKEN=${{ secrets.BLOB_READ_WRITE_TOKEN }}" >> $GITHUB_ENV
+            echo "VERCEL_ENV=production" >> $GITHUB_ENV
           fi
           echo "Environment: ${{ github.event.inputs.run_env }}"
 
@@ -93,7 +95,7 @@ jobs:
         env:
           BLOB_READ_WRITE_TOKEN: ${{ env.BLOB_READ_WRITE_TOKEN }}
           BLOB_ALLOW_OVERWRITE: 'true'
-          VERCEL_ENV: ${{ github.event.inputs.run_env }}
+          VERCEL_ENV: ${{ env.VERCEL_ENV }}
         run: |
           node api/qa-test.js \
             input.xlsx \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ The QA Automation Tool:
 
 ---
 
+## Environment Setup
+
+Configure these variables when running locally or in GitHub Actions:
+
+- `BLOB_READ_WRITE_TOKEN` – production storage access token
+- `TEST_BLOB_READ_WRITE_TOKEN` – preview/test storage token
+- `VERCEL_ENV` – set to `production` or `preview` during runs
+- Other secrets like `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` and `QA_PASSPHRASE`
+
+---
+
 ## Key Features
 
 ### Dashboard


### PR DESCRIPTION
## Summary
- standardize naming for preview blob token
- document environment variables
- set `VERCEL_ENV` automatically from `run_env`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e2bf50ca483218995b53295738bdc