### PR TITLE
Fix cleanup script to ES modules

### DIFF
--- a/scripts/cleanup-supabase.js
+++ b/scripts/cleanup-supabase.js
@@ -1,5 +1,5 @@
 // Removes old records from Supabase tables older than 60 days
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Summary
- convert `scripts/cleanup-supabase.js` to ES module syntax

## Testing
- `node --check scripts/cleanup-supabase.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d4fa6dd0483218c12c57cde5e1e9f