### PR TITLE
Add keep-alive workflow for Preview

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,24 @@
+name: Keep Preview Supabase Alive
+
+on:
+  schedule:
+    - cron: '0 0 */5 * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    environment: Preview
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Ping Supabase
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: node scripts/ping-supabase.js

--- a/scripts/cleanup-supabase.js
+++ b/scripts/cleanup-supabase.js
@@ -1,5 +1,5 @@
 // Removes old records from Supabase tables older than 60 days
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/scripts/ping-supabase.js
+++ b/scripts/ping-supabase.js
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set');
+  process.exit(1);
+}
+
+const supabase = createClient(url, key);
+
+try {
+  const { error } = await supabase.from('test_runs').select('id').limit(1);
+  if (error) {
+    console.error('Ping failed:', error.message);
+    process.exit(1);
+  }
+  console.log('Supabase ping successful');
+} catch (err) {
+  console.error('Ping failed:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- fix cleanup script to use ES module syntax
- add ping-supabase script
- add GitHub Actions workflow to keep Preview Supabase active

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d4d769ab083218d5f07b1220dd8e5