### PR TITLE
Fix Supabase keepalive query

### DIFF
--- a/scripts/ping-supabase.js
+++ b/scripts/ping-supabase.js
@@ -11,7 +11,11 @@ if (!url || !key) {
 const supabase = createClient(url, key);
 
 try {
-  const { error } = await supabase.from('test_runs').select('id').limit(1);
+  // The test_runs table uses run_id as the primary key. Selecting a
+  // non-existent id column caused the previous keep-alive job to fail
+  // with "column test_runs.id does not exist". Query a valid column
+  // to verify connectivity instead.
+  const { error } = await supabase.from('test_runs').select('run_id').limit(1);
   if (error) {
     console.error('Ping failed:', error.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- query the actual `run_id` field in ping-supabase.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852289eb24c8321a83253c9070109bf