### PR TITLE
Fix Supabase keep-alive ping

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -2,7 +2,7 @@ name: Keep Preview Supabase Alive
 
 on:
   schedule:
-    - cron: '0 0 */5 * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
           node-version: '20'
       - name: Install dependencies
         run: npm ci
-      - name: Ping Supabase
+      - name: Ping Supabase (SQL)
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/scripts/ping-supabase.js
+++ b/scripts/ping-supabase.js
@@ -1,27 +1,27 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.SUPABASE_URL;
-const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+(async () => {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-if (!url || !key) {
-  console.error('SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set');
-  process.exit(1);
-}
-
-const supabase = createClient(url, key);
-
-try {
-  // The test_runs table uses run_id as the primary key. Selecting a
-  // non-existent id column caused the previous keep-alive job to fail
-  // with "column test_runs.id does not exist". Query a valid column
-  // to verify connectivity instead.
-  const { error } = await supabase.from('test_runs').select('run_id').limit(1);
-  if (error) {
-    console.error('Ping failed:', error.message);
+  if (!url || !key) {
+    console.error('❌ SUPABASE_URL or SERVICE_ROLE_KEY missing');
     process.exit(1);
   }
-  console.log('Supabase ping successful');
-} catch (err) {
-  console.error('Ping failed:', err.message);
-  process.exit(1);
-}
+
+  const supabase = createClient(url, key, {
+    localStorage: null,
+    detectSessionInUrl: false
+  });
+
+  try {
+    // Execute a trivial SQL call so the database registers activity
+    const { data, error } = await supabase.rpc('select_one');
+    if (error) throw error;
+    console.log('✅ Supabase SQL ping result:', data);
+    process.exit(0);
+  } catch (err) {
+    console.error('❌ Supabase ping failed:', err.message || err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- ping Supabase with a minimal SQL RPC call
- update keepalive workflow to run every 6 hours

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856d98cbbb0832181ede0ec1f3ab17f