### PR TITLE
Fix keepalive script

### DIFF
--- a/scripts/keepalive-test-supabase.js
+++ b/scripts/keepalive-test-supabase.js
@@ -9,31 +9,35 @@ import { createClient } from '@supabase/supabase-js';
     process.exit(1);
   }
 
-  const supabase = createClient(url, key, {
-    localStorage: null,
-    detectSessionInUrl: false
-  });
+  const supabase = createClient(url, key);
 
   try {
     // Insert a heartbeat row so Supabase registers write activity
     const { error } = await supabase
       .from('keepalive')
       .insert({ created_at: new Date().toISOString() });
-    if (error) throw error;
+    if (error) {
+      console.error('❌ Supabase keepalive insert failed:', JSON.stringify(error));
+      process.exit(1);
+    }
     console.log('✅ Inserted keepalive row');
   } catch (err) {
-    console.error('❌ Supabase keepalive insert failed:', err.message || err);
+    console.error('❌ Unexpected error during keepalive insert:', err);
     process.exit(1);
   }
 
   try {
     // Optionally prune rows older than 60 days to avoid unbounded growth
     const cutoff = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
-    await supabase
+    const { error } = await supabase
       .from('keepalive')
       .delete()
       .lt('created_at', cutoff);
+    if (error) {
+      console.warn('⚠️ Keepalive cleanup failed:', JSON.stringify(error));
+    }
   } catch (err) {
-    console.warn('⚠️ Keepalive cleanup failed:', err.message || err);
+    console.warn('⚠️ Keepalive cleanup error:', err);
   }
 })();
+


### PR DESCRIPTION
## Summary
- update keepalive script to match production client options
- improve error logging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866988ce2408321a0e8b8c25420cbd2