### PR TITLE
Add fallback for missing keepalive table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Runs a predefined suite of end-to-end checks, aggregates results in real time, a
 
 ### Preview DB Keepalive
 
-The workflow **Keep Test Supabase Alive** now inserts a heartbeat row every three days using `scripts/keepalive-test-supabase.js`. It expects `SUPABASE_TEST_URL` and `SUPABASE_TEST_SERVICE_ROLE_KEY` secrets. The script writes to a small `keepalive` table and prunes old rows to show ongoing activity.
+The workflow **Keep Test Supabase Alive** inserts a heartbeat row every three days using `scripts/keepalive-test-supabase.js`. It expects `SUPABASE_TEST_URL` and `SUPABASE_TEST_SERVICE_ROLE_KEY` secrets. The script writes to a small `keepalive` table and prunes old rows to show ongoing activity. If that table doesn't exist, it falls back to a simple read query so the database still registers usage.
 
 ---
 

--- a/scripts/keepalive-test-supabase.js
+++ b/scripts/keepalive-test-supabase.js
@@ -11,16 +11,39 @@ import { createClient } from '@supabase/supabase-js';
 
   const supabase = createClient(url, key);
 
+  async function fallbackQuery() {
+    try {
+      const { error } = await supabase
+        .from('test_results')
+        .select('id')
+        .limit(1);
+      if (error) throw error;
+      console.log('✅ Fallback Supabase query succeeded');
+    } catch (err) {
+      console.error('❌ Supabase fallback query failed:', err);
+      process.exit(1);
+    }
+  }
+
   try {
     // Insert a heartbeat row so Supabase registers write activity
     const { error } = await supabase
       .from('keepalive')
       .insert({ created_at: new Date().toISOString() });
+
     if (error) {
-      console.error('❌ Supabase keepalive insert failed:', JSON.stringify(error));
-      process.exit(1);
+      const missing = error.status === 404 ||
+        (error.message && error.message.includes('does not exist'));
+      if (missing) {
+        console.warn('⚠️ keepalive table missing, running fallback query');
+        await fallbackQuery();
+      } else {
+        console.error('❌ Supabase keepalive insert failed:', JSON.stringify(error));
+        process.exit(1);
+      }
+    } else {
+      console.log('✅ Inserted keepalive row');
     }
-    console.log('✅ Inserted keepalive row');
   } catch (err) {
     console.error('❌ Unexpected error during keepalive insert:', err);
     process.exit(1);
@@ -34,10 +57,16 @@ import { createClient } from '@supabase/supabase-js';
       .delete()
       .lt('created_at', cutoff);
     if (error) {
-      console.warn('⚠️ Keepalive cleanup failed:', JSON.stringify(error));
+      const missing = error.status === 404 ||
+        (error.message && error.message.includes('does not exist'));
+      if (!missing) {
+        console.warn('⚠️ Keepalive cleanup failed:', JSON.stringify(error));
+      }
     }
   } catch (err) {
-    console.warn('⚠️ Keepalive cleanup error:', err);
+    if (!(err && err.message && err.message.includes('does not exist'))) {
+      console.warn('⚠️ Keepalive cleanup error:', err);
+    }
   }
 })();
 


### PR DESCRIPTION
## Summary
- update keepalive script to fallback to simple query when the table isn't present
- clarify README keepalive workflow description

## Testing
- `npm ci` *(fails: MaxListenersExceededWarning and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68669a93ad8c8321931446917a82cd9e