### PR TITLE
chore: pause test Supabase keepalive

### DIFF
--- a/.github/workflows/supabase-test-keepalive.yml
+++ b/.github/workflows/supabase-test-keepalive.yml
@@ -1,8 +1,10 @@
 name: Keep Test Supabase Alive
 
 on:
-  schedule:
-    - cron: '0 0 */3 * *'
+  # The test Supabase instance is currently paused, so disable the scheduled
+  # keepalive pings. The workflow can still be run manually if needed.
+  # schedule:
+  #   - cron: '0 0 */3 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- disable scheduled Supabase keepalive workflow; run manually only

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68b5173c21788321baaa77cb2bfd2a99